### PR TITLE
Fix problem with starter theme

### DIFF
--- a/controllers/front/ajax.php
+++ b/controllers/front/ajax.php
@@ -20,6 +20,9 @@ class PrettyBlocksAjaxModuleFrontController extends ModuleFrontController
     {
         if (empty($_POST)) {
             $_POST = json_decode(file_get_contents("php://input"),true);
+            if (!is_array($_POST)) {
+                $_POST = [];
+            }
         }
         if(empty($this->ajax_token) || Tools::getValue('ajax_token') !== $this->ajax_token)
         {


### PR DESCRIPTION
Fix a problem  with theme https://github.com/Oksydan/falcon v2.3.1. and Prestashop 1.7.8.7
In back office, encouter error 
` PHP Fatal error:  Uncaught TypeError: Argument 2 passed to Symfony\\Component\\HttpFoundation\\Request::createRequestFromFactory() must be of the type array, null given ....`