### PR TITLE
Add classname as a common parameter for all blocks, and split block and default settings in an accordion

### DIFF
--- a/_dev/src/components/RightPanel.vue
+++ b/_dev/src/components/RightPanel.vue
@@ -184,23 +184,26 @@ emitter.on('globalSave', () => {
 
     <!-- Config panel -->
     <div v-if="config" id="configPanel" class="absolute top-0 left-0 overflow-y-auto w-full h-full flex flex-col p-2 bg-slate-100" @keyup.enter="saveConfig()">
-      <template v-for="f in config" :key="f">
-        <FieldRepeater @updateUpload="saveConfig()" :field="f" />
-      </template>
-      {{ trans('default_settings') }}
-      <Checkbox class="my-4" v-model="config.default.container" :title="trans('use_container')" name="container" />
-      {{ trans('bg_color') }}
-      <div class="flex mb-4 pt-4">
-        <ColorInput class="flex-auto rounded-full" v-model="config.default.bg_color" format="hex string" />
-        <Input class="flex-auto" :placeholder="trans('ex_color')" v-model="config.default.bg_color" name="bg_color" />
-      </div>
-      {{ trans('css_class') }}
-      <div class="flex mb-4 pt-4">
-        <Input class="flex-auto" :placeholder="trans('ex_css_class')" v-model="config.default.css_class" name="css_class" />
-      </div>
-      <SimpleSelect v-if="Object.keys(config.templates).length > 1" v-model="config.templateSelected"
-        :availableTpl="config.templates" :currentTpl="config.templateSelected"
-        @update="value => console.log('value', value)" :label="trans('choose_template')" />
+      <Accordion :title="trans('block_settings')" :open="true">
+        <template v-for="f in config" :key="f">
+          <FieldRepeater @updateUpload="saveConfig()" :field="f" />
+        </template>
+      </Accordion>
+      <Accordion :title="trans('default_settings')">
+        <Checkbox class="my-4" v-model="config.default.container" :title="trans('use_container')" name="container" />
+        {{ trans('bg_color') }}
+        <div class="flex mb-4 pt-4">
+          <ColorInput class="flex-auto rounded-full" v-model="config.default.bg_color" format="hex string" />
+          <Input class="flex-auto" :placeholder="trans('ex_color')" v-model="config.default.bg_color" name="bg_color" />
+        </div>
+        {{ trans('css_class') }}
+        <div class="flex mb-4 pt-4">
+          <Input class="flex-auto" :placeholder="trans('ex_css_class')" v-model="config.default.css_class" name="css_class" />
+        </div>
+        <SimpleSelect v-if="Object.keys(config.templates).length > 1" v-model="config.templateSelected"
+          :availableTpl="config.templates" :currentTpl="config.templateSelected"
+          @update="value => console.log('value', value)" :label="trans('choose_template')" />
+      </Accordion>
     </div>
 
     <!-- State panel  -->

--- a/_dev/src/components/RightPanel.vue
+++ b/_dev/src/components/RightPanel.vue
@@ -194,6 +194,10 @@ emitter.on('globalSave', () => {
         <ColorInput class="flex-auto rounded-full" v-model="config.default.bg_color" format="hex string" />
         <Input class="flex-auto" :placeholder="trans('ex_color')" v-model="config.default.bg_color" name="bg_color" />
       </div>
+      {{ trans('css_class') }}
+      <div class="flex mb-4 pt-4">
+        <Input class="flex-auto" :placeholder="trans('ex_css_class')" v-model="config.default.css_class" name="css_class" />
+      </div>
       <SimpleSelect v-if="Object.keys(config.templates).length > 1" v-model="config.templateSelected"
         :availableTpl="config.templates" :currentTpl="config.templateSelected"
         @update="value => console.log('value', value)" :label="trans('choose_template')" />

--- a/classes/PrettyBlocksMigrate.php
+++ b/classes/PrettyBlocksMigrate.php
@@ -326,6 +326,7 @@ class PrettyBlocksMigrate
             'container' => true,
             'load_ajax' => false,
             'bg_color' => '',
+            'css_class' => '',
         ];
         $defaultParams = \Configuration::get($key);
         if (!$defaultParams) {

--- a/classes/PrettyBlocksModel.php
+++ b/classes/PrettyBlocksModel.php
@@ -583,6 +583,7 @@ class PrettyBlocksModel extends ObjectModel
             'container' => true,
             'load_ajax' => false,
             'bg_color' => '',
+            'css_class' => '',
         ];
         $defaultParams = $this->getDefaultParams();
         if (!$defaultParams) {

--- a/src/Controller/AdminThemeManagerController.php
+++ b/src/Controller/AdminThemeManagerController.php
@@ -240,6 +240,7 @@ class AdminThemeManagerController extends FrameworkBundleAdminController
                 'current_zone' => $translator->trans('Current zone', [], 'Modules.Prettyblocks.Admin'),
                 'loading' => $translator->trans('Loading', [], 'Modules.Prettyblocks.Admin'),
                 'default_settings' => $translator->trans('Default settings', [], 'Modules.Prettyblocks.Admin'),
+                'block_settings' => $translator->trans('Block settings', [], 'Modules.Prettyblocks.Admin'),
                 'choose_template' => $translator->trans('Choose a template', [], 'Modules.Prettyblocks.Admin'),
                 'use_container' => $translator->trans('Place the element in a column (container)', [], 'Modules.Prettyblocks.Admin'),
                 'bg_color' => $translator->trans('Background color', [], 'Modules.Prettyblocks.Admin'),

--- a/src/Controller/AdminThemeManagerController.php
+++ b/src/Controller/AdminThemeManagerController.php
@@ -244,6 +244,8 @@ class AdminThemeManagerController extends FrameworkBundleAdminController
                 'use_container' => $translator->trans('Place the element in a column (container)', [], 'Modules.Prettyblocks.Admin'),
                 'bg_color' => $translator->trans('Background color', [], 'Modules.Prettyblocks.Admin'),
                 'ex_color' => $translator->trans('Add a color ex: #123456', [], 'Modules.Prettyblocks.Admin'),
+                'css_class' => $translator->trans('CSS Classname', [], 'Modules.Prettyblocks.Admin'),
+                'ex_css_class' => $translator->trans('You can input multiple classes : class1 class2 class3', [], 'Modules.Prettyblocks.Admin'),
                 'theme_settings' => $translator->trans('Theme settings', [], 'Modules.Prettyblocks.Admin'),
                 'type_search_here' => $translator->trans('Type your search here', [], 'Modules.Prettyblocks.Admin'),
             ],

--- a/translations/fr-FR/ModulesPrettyblocksAdmin.fr-FR.xlf
+++ b/translations/fr-FR/ModulesPrettyblocksAdmin.fr-FR.xlf
@@ -106,6 +106,11 @@
         <source>Background color</source>
         <target>Couleur de fond</target>
         <note>Line: </note>
+      </trans-unit>   
+      <trans-unit id="d4bc72be9854ed72e4a1da1509021bf4">
+        <source>Block settings</source>
+        <target>Paramètres du bloc</target>
+        <note>Line: </note>
       </trans-unit>
       <trans-unit id="8c2df8fa44696764ce81d46010fbeab4">
         <source>Add a color ex: #123456</source>

--- a/translations/fr-FR/ModulesPrettyblocksAdmin.fr-FR.xlf
+++ b/translations/fr-FR/ModulesPrettyblocksAdmin.fr-FR.xlf
@@ -112,6 +112,16 @@
         <target>Ajoutez une couleur ex: #121212</target>
         <note>Line: </note>
       </trans-unit>
+      <trans-unit id="e79b239b1d6059e081294d801a7acfdd">
+        <source>CSS Classname</source>
+        <target>Classe CSS</target>
+        <note>Line: </note>
+      </trans-unit>
+      <trans-unit id="f835f67e99325d0cc2a9ac1a50f11f6c">
+        <source>You may input multiple classes : class1 class2 class3</source>
+        <target>Vous pouvez insérer plusieurs classes : class1 class2 class3</target>
+        <note>Line: </note>
+      </trans-unit>
       <trans-unit id="55b8deb25fdc0f8b628027f7d1d21cbe">
         <source>Theme settings</source>
         <target>Paramètres du thème</target>


### PR DESCRIPTION
Use it in templates like this :

```
class="{$block.settings.default.css_class|default:''}"
```