### PR TITLE
fix(upgrade): fix 3.0.2 upgrade bad function name

### DIFF
--- a/upgrade/upgrade-3.0.2.php
+++ b/upgrade/upgrade-3.0.2.php
@@ -29,7 +29,7 @@ if (!defined('_PS_VERSION_')) {
  * @throws PrestaShopDatabaseException
  * @throws PrestaShopException
  */
-function upgrade_module_3_0_0($module)
+function upgrade_module_3_0_2($module)
 {
     \Configuration::deleteByName('_PRETTYBLOCKS_TOKEN_');
     \Configuration::updateGlobalValue('_PRETTYBLOCKS_TOKEN_', \Tools::passwdGen(25));


### PR DESCRIPTION
3.0.2 function name was 3.0.0, which caused a duplicate function name error during the upgrade process.