### PR TITLE
feat(tinymce): notification removal revert

### DIFF
--- a/_dev/src/components/FieldRepeater.vue
+++ b/_dev/src/components/FieldRepeater.vue
@@ -48,13 +48,6 @@ const emit = defineEmits(['updateUpload'])
 const updateUpload = () => {
   emit('updateUpload')
 }
-const removeTinyNotifications = () => {
-  setTimeout(() => {
-    document.querySelectorAll('.tox-notifications-container').forEach((el) => {
-      el.querySelector('button.tox-notification__dismiss').click()
-    })
-  }, 300)
-}
 let tinymce_api_key = ref(window.security_app.tinymce_api_key)
 
 </script>
@@ -82,7 +75,6 @@ let tinymce_api_key = ref(window.security_app.tinymce_api_key)
       <Editor
         v-model="f.value"
         :api-key="tinymce_api_key"
-        @init="removeTinyNotifications()"
         :init="{
           height: 500,
           menubar: 'edit view format',


### PR DESCRIPTION
TinyMCE notification display removal prevent the user to be informed that his API Key is not valid or that the domain is not whitelisted, I think it's better to keep it displayed