### PR TITLE
FieldCore : notice when a field with a collection is saved

### DIFF
--- a/classes/prettyblocks/core/FieldCore.php
+++ b/classes/prettyblocks/core/FieldCore.php
@@ -605,7 +605,7 @@ class FieldCore
             return $this->_getCollection($idCollection, $this->collection);
         }
         // if value doesn't exists in DB and new value is set
-        if ($this->force_default_value && $this->new_value == '') {
+        if ($this->force_default_value && $this->new_value === '' && is_array($this->default) && isset($this->default['show']['id'])) {
             $idCollection = (int) $this->default['show']['id'];
 
             return $this->_getCollection($idCollection, $this->collection);


### PR DESCRIPTION
A notice is triggered when when a field with a collection is saved on backoffice without default value, a notice is triggered.

(1/1) ContextErrorException

Notice: Trying to access array offset on value of type null in FieldCore.php line 609