### PR TITLE
fix: left panel flex grow issue

### DIFF
--- a/_dev/src/components/LeftPanel.vue
+++ b/_dev/src/components/LeftPanel.vue
@@ -215,7 +215,7 @@ prettyBlocksContext.on('iframeLoaded', () => {
     <div class="flex flex-col h-full">
       <div class="p-2 border-b border-gray-200">
         <div class="flex items-center space-around">
-          <div>
+          <div class="flex-grow">
             <ZoneSelect v-model="state" />
           </div>
           <div class="pl-2 mt-[6px]">


### PR DESCRIPTION
Add flex-grow to ZoneSelect container un left panel to be able to see clearly the zone names