### PR TITLE
Fix : Prevent mergeStateWithFields to be played twice in the frontend

### DIFF
--- a/classes/PrettyBlocksModel.php
+++ b/classes/PrettyBlocksModel.php
@@ -153,10 +153,8 @@ class PrettyBlocksModel extends ObjectModel
         $blocks = [];
         foreach ($psc->getResults() as $res) {
             if ($res) {
-                $block = $res->mergeStateWithFields();
-                if ($context == 'front') {
-                    $block = (new BlockPresenter())->present($res->mergeStateWithFields($id_lang));
-                }
+                $block = $res->mergeStateWithFields($context === 'front' ? $id_lang : null);
+                $block = $context === 'front' ? (new BlockPresenter())->present($block) : $block;
                 $blocks[] = $block;
             }
         }


### PR DESCRIPTION
In the front-end, the mergeStateWithFields function is played twice to render a block, but this function uses the “beforeRendering...” hooks, which can be cumbersome (for example, fetch products and use a presenter to transform the products into ProductLazyArray could dramatically hurt the TTFB).

This PR fixes this issue