### PR TITLE
Fix : Prevent images to be overwritten if they have the same name

### DIFF
--- a/src/Controller/AdminThemeManagerController.php
+++ b/src/Controller/AdminThemeManagerController.php
@@ -62,8 +62,19 @@ class AdminThemeManagerController extends FrameworkBundleAdminController
         $extension = strtolower(pathinfo($file['name'], PATHINFO_EXTENSION));
         $imgs = [];
         if (in_array($extension, \Module::getInstanceByName('prettyblocks')->valid_types)) {
+            $md5ContentSuffix = '';
+            $content = \Tools::file_get_contents($file['tmp_name']);
+
+            if ($content !== false) {
+                $md5ContentSuffix = '_' . md5($content);
+            }
+            
             // can upload
-            $new_name = \Tools::str2url(pathinfo($file['name'], PATHINFO_FILENAME));
+            $new_name = \Tools::str2url(pathinfo($file['name'], PATHINFO_FILENAME) . $md5ContentSuffix);
+
+            // Most OS have a limit of 255 characters for file names
+            $new_name = \Tools::substr($new_name, 0, 255 - \Tools::strlen('.' . $extension));
+            
             $path = '$/modules/prettyblocks/views/images/';
             if (\Tools::getIsset('path')) {
                 $path = pSQL(\Tools::getValue('path'));


### PR DESCRIPTION
For exemple : on a block that has a repeater. Let's say that each repeater item has an image upload field. If I upload an image toto.png for the first item and then I upload another image with the same name but not the same content, then the first image will be overwritten by the second image.

This PR adds a md5 of the content of the file to the filename