### PR TITLE
Fix Symfony URL on PrestaShop 9

### DIFF
--- a/src/Controller/AdminThemeManagerController.php
+++ b/src/Controller/AdminThemeManagerController.php
@@ -154,7 +154,9 @@ class AdminThemeManagerController extends FrameworkBundleAdminController
      */
     private function getSFUrl($route, $entity = 'sf')
     {
-        $domain = \Tools::getShopDomainSsl(true);
+        $useDomain = version_compare(_PS_VERSION_, '9.0.0.0', '<');
+
+        $domain = $useDomain ? '' : \Tools::getShopDomainSsl(true);
 
         return $domain . \Link::getUrlSmarty([
             'entity' => $entity,


### PR DESCRIPTION
Avoid double domain by checking PrestaShop version before prepending $domain